### PR TITLE
Document moviepy install and guard import

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,12 @@ The repository includes a small utility (`overlay_gif.py`) that demonstrates how
 to place an animated GIF on top of an MP4 file at a specific time and position.
 It relies on the [`moviepy`](https://zulko.github.io/moviepy/) library.
 
+If you haven't installed `moviepy`, you can do so with:
+
+```bash
+pip install moviepy
+```
+
 Example usage:
 
 ```bash

--- a/overlay_gif.py
+++ b/overlay_gif.py
@@ -16,7 +16,13 @@ from __future__ import annotations
 import argparse
 from typing import Tuple, Union
 
-from moviepy.editor import VideoFileClip, CompositeVideoClip
+try:
+    from moviepy.editor import VideoFileClip, CompositeVideoClip
+except ImportError as exc:  # pragma: no cover - moviepy is optional
+    raise ImportError(
+        "The moviepy package is required for this script."
+        " Install it with 'pip install moviepy'."
+    ) from exc
 
 
 def overlay_gif_on_video(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,5 @@ dependencies = [
     "numpy>=2.2.5",
     "parakeet-mlx>=0.2.6",
     "sounddevice>=0.5.1",
+    "moviepy>=1.0.3",
 ]


### PR DESCRIPTION
## Summary
- handle missing `moviepy` with a helpful message
- document how to install `moviepy`
- declare `moviepy` dependency

## Testing
- `python -m pytest` *(fails: No module named pytest)*