### PR TITLE
Add GIF timing and video trimming options

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,8 +219,9 @@ The `enhanced_transcription.py` script can be integrated with other tools:
 ### Overlaying GIFs onto a Video
 
 The repository includes a small utility (`overlay_gif.py`) that demonstrates how
-to place an animated GIF on top of an MP4 file at a specific time and position.
-It relies on the [`moviepy`](https://zulko.github.io/moviepy/) library.
+to place an animated GIF on top of an MP4 file. The script can trim the input
+video to a specific range and control when the GIF appears and disappears. It
+relies on the [`moviepy`](https://zulko.github.io/moviepy/) library.
 
 If you haven't installed `moviepy`, you can do so with:
 
@@ -228,15 +229,28 @@ If you haven't installed `moviepy`, you can do so with:
 pip install moviepy
 ```
 
-Example usage:
+Basic usage:
 
 ```bash
 python overlay_gif.py --video input.mp4 --gif anim.gif \
-    --start 5 --position center --output output.mp4
+    --gif-start 5 --position center --output output.mp4
 ```
 
-This will insert `anim.gif` in the center of `input.mp4`, starting five seconds
-into the video, and save the result as `output.mp4`.
+This inserts `anim.gif` in the center of `input.mp4`, starting five seconds into
+the video, and saves the result as `output.mp4`.
+
+You can also trim the source video and specify when the GIF disappears:
+
+```bash
+python overlay_gif.py --video input.mp4 --gif anim.gif \
+    --clip-start 10 --clip-end 20 \
+    --gif-start 2 --gif-end 8 --position "100,200" \
+    --output clipped.mp4
+```
+
+This cuts `input.mp4` to the 10–20 second range and overlays `anim.gif` at the
+coordinates (100, 200) from two seconds into the clip until the eight-second
+mark.
 
 ### Customizing the Model
 

--- a/overlay_gif.py
+++ b/overlay_gif.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """Overlay an animated GIF onto an MP4 video.
 
-This script uses ``moviepy`` to place a GIF on top of a video at a
-specific time and position.
+This script uses ``moviepy`` to place a GIF on top of a video. It can
+optionally trim the input video and control when the GIF appears and
+disappears.
 
 Example usage::
 
     python overlay_gif.py --video input.mp4 --gif anim.gif \
-        --start 5 --position center --output output.mp4
+        --gif-start 5 --position center --output output.mp4
 
 """
 
@@ -29,7 +30,10 @@ def overlay_gif_on_video(
     video_path: str,
     gif_path: str,
     output_path: str,
-    start_time: float = 0.0,
+    clip_start: float = 0.0,
+    clip_end: float | None = None,
+    gif_start: float = 0.0,
+    gif_end: float | None = None,
     position: Union[str, Tuple[int, int]] = (0, 0),
 ) -> None:
     """Overlay ``gif_path`` onto ``video_path``.
@@ -42,18 +46,27 @@ def overlay_gif_on_video(
         Path to the animated GIF to overlay.
     output_path:
         Where to save the resulting video.
-    start_time:
+    clip_start:
+        Start time of the extracted video clip.
+    clip_end:
+        End time of the extracted video clip. ``None`` means to use the end of
+        the source video.
+    gif_start:
         Time (in seconds) when the GIF should appear.
+    gif_end:
+        Time (in seconds) when the GIF should disappear. ``None`` means to use
+        the GIF's full duration.
     position:
         Coordinates or keyword position for the GIF.
     """
 
     video_clip = VideoFileClip(video_path)
-    gif_clip = (
-        VideoFileClip(gif_path)
-        .set_start(start_time)
-        .set_position(position)
-    )
+    if clip_start != 0.0 or clip_end is not None:
+        video_clip = video_clip.subclip(clip_start, clip_end)
+
+    gif_clip = VideoFileClip(gif_path).set_start(gif_start).set_position(position)
+    if gif_end is not None:
+        gif_clip = gif_clip.set_end(gif_end)
 
     final_clip = CompositeVideoClip([video_clip, gif_clip])
     final_clip.write_videofile(output_path, codec="libx264", audio_codec="aac")
@@ -64,7 +77,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--video", required=True, help="Input MP4 video path")
     parser.add_argument("--gif", required=True, help="GIF file to overlay")
     parser.add_argument("--output", required=True, help="Output MP4 path")
-    parser.add_argument("--start", type=float, default=0.0, help="Time in seconds when the GIF appears")
+    parser.add_argument("--clip-start", type=float, default=0.0, help="Start time of the video clip")
+    parser.add_argument("--clip-end", type=float, default=None, help="End time of the video clip")
+    parser.add_argument("--gif-start", "--start", dest="gif_start", type=float, default=0.0, help="Time in seconds when the GIF appears")
+    parser.add_argument("--gif-end", type=float, default=None, help="Time in seconds when the GIF disappears")
     parser.add_argument(
         "--position",
         default="center",
@@ -86,7 +102,10 @@ def main() -> None:
         video_path=args.video,
         gif_path=args.gif,
         output_path=args.output,
-        start_time=args.start,
+        clip_start=args.clip_start,
+        clip_end=args.clip_end,
+        gif_start=args.gif_start,
+        gif_end=args.gif_end,
         position=pos,
     )
 


### PR DESCRIPTION
## Summary
- extend `overlay_gif.py` to trim source video and control GIF timing
- update documentation with new usage examples

## Testing
- `pytest -q` *(fails: command not found)*